### PR TITLE
SLING-8205 stop spitting NSFE

### DIFF
--- a/src/main/java/org/apache/sling/scripting/sightly/compiler/util/ObjectModel.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/compiler/util/ObjectModel.java
@@ -366,12 +366,17 @@ public final class ObjectModel {
         if (cls.isArray() && "length".equals(fieldName)) {
             return Array.getLength(object);
         }
-        try {
-            Field field = cls.getField(fieldName);
-            return field.get(object);
-        } catch (Exception e) {
-            return null;
+        for (Field field : cls.getFields()){
+            if (field.getName().equals(fieldName)){
+                try {
+                    return field.get(object);
+                }
+                catch (IllegalAccessException e) {
+                    return null;
+                }
+            }
         }
+        return null;
     }
 
     /**


### PR DESCRIPTION
crawling through getFields. This can still send an IllegalAccessException, but this happens much less