### PR TITLE
SLING-12325 - Improve parsing of tricky expressions

### DIFF
--- a/src/test/java/org/apache/sling/scripting/sightly/impl/compiler/SightlyCompilerTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/compiler/SightlyCompilerTest.java
@@ -238,6 +238,14 @@ public class SightlyCompilerTest {
         assertTrue(secondArgument instanceof MapLiteral);
     }
 
+    @Test
+    public void testMarkupInStringLiteral() {
+        CompilationResult result = compileFile("/markup-in-string-literal.html");
+        assertTrue(
+                "Didn't expect any warnings or errors.",
+                result.getErrors().isEmpty() && result.getWarnings().isEmpty());
+    }
+
     private CompilationResult compileFile(final String file) {
         InputStream stream = this.getClass().getResourceAsStream(file);
         final Reader reader = new InputStreamReader(stream);

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/html/dom/HtmlParserTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/html/dom/HtmlParserTest.java
@@ -244,6 +244,29 @@ public class HtmlParserTest {
                 handler.onStartElementInvocations);
     }
 
+    @Test
+    public void testTrickyStringLiterals() throws IOException {
+        String[] testStrings = new String[] {
+            "${'easy case'}",
+            "${'looks like <html> but isn\\'t}",
+            "${'not over yet } but now it's over'}",
+            "${'not over } <br> now it's over'}",
+            "${'brace } <html> } escaped apos \\' } done'}",
+            "${\"brace } <html> } escaped quote \\\" } done\"}"
+        };
+
+        for (String testString : testStrings) {
+            Template reference = new Template();
+            reference.addChild(new TemplateTextNode(testString));
+
+            TemplateParser.TemplateParserContext context = new TemplateParser.TemplateParserContext();
+            HtmlParser.parse(new StringReader(testString), context);
+            Template parsed = context.getTemplate();
+
+            assertSameStructure(reference, parsed);
+        }
+    }
+
     abstract class AbstractDocumentHandler implements DocumentHandler {
 
         private String lastProcessedTag;

--- a/src/test/resources/markup-in-string-literal.html
+++ b/src/test/resources/markup-in-string-literal.html
@@ -1,0 +1,19 @@
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+${'Click <a href="{0}">here</a> to learn more' @ format='https://example.com/'}


### PR DESCRIPTION
To detect the end of the expression properly, it isn't enough to look for a closing brace, we also need to ensure that the brace is outside of a string literal.